### PR TITLE
[Ft/ci]: Add Continuous Integration and deployment pipeline for back-end and model

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,25 @@
+name: Deploy to Production
+on:
+  push:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  deploy-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: test and build container
+        working-directory: ./server
+        run: |
+          go test ./... 
+          docker build -t server .
+          docker tag server registry.heroku.com/sem-test-1101/web
+      - name: login to heroku and push image
+        run: |
+          docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
+          docker push registry.heroku.com/sem-test-1101/web
+        env:
+          HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
+          

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,17 +18,14 @@ jobs:
           docker tag server registry.heroku.com/sem-test-1101/web
       - name: login to heroku and push image
         run: |
-          docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
+          docker login --username=_ --password=$HEROKU_API_KEY registry.heroku.com
           docker push registry.heroku.com/sem-test-1101/web
           
           curl https://cli-assets.heroku.com/install.sh | sh
           heroku --version # verify install
-          echo "machine api.heroku.com\n\tlogin mcantacu@andrew.cmu.edu\n\tpassword $HEROKU_AUTH_TOKEN" > ~/.netrc
-          cat ~/.netrc
           
           heroku container:release web -a sem-test-1101
         env:
-          HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
   
   deploy-ml:
@@ -44,14 +41,14 @@ jobs:
         run: |
           APP_NAME=sem-ml-1101
 
-          docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
+          docker login --username=_ --password=$HEROKU_API_KEY registry.heroku.com
           docker push registry.heroku.com/$APP_NAME/web
           
           curl https://cli-assets.heroku.com/install.sh | sh
           heroku --version
-          echo "machine api.heroku.com\n\tlogin mcantacu@andrew.cmu.edu\n\tpassword $HEROKU_AUTH_TOKEN" > ~/.netrc
-          cat ~/.netrc 
 
           heroku container:release web -a APP_NAME
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
 
           

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,10 +24,12 @@ jobs:
           curl https://cli-assets.heroku.com/install.sh | sh
           heroku --version # verify install
           echo "machine api.heroku.com\n\tlogin mcantacu@andrew.cmu.edu\n\tpassword $HEROKU_AUTH_TOKEN" > ~/.netrc
+          cat ~/.netrc
           
           heroku container:release web -a sem-test-1101
         env:
           HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
+          HEROKU_API_KEY: ${{ secrets.HEROKU_AUTH_TOKEN }}
   
   deploy-ml:
     runs-on: ubuntu-latest
@@ -42,13 +44,14 @@ jobs:
         run: |
           APP_NAME=sem-ml-1101
 
-          docker login --usrename=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
+          docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
           docker push registry.heroku.com/$APP_NAME/web
           
           curl https://cli-assets.heroku.com/install.sh | sh
           heroku --version
           echo "machine api.heroku.com\n\tlogin mcantacu@andrew.cmu.edu\n\tpassword $HEROKU_AUTH_TOKEN" > ~/.netrc
-          
+          cat ~/.netrc 
+
           heroku container:release web -a APP_NAME
 
           

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,6 +20,35 @@ jobs:
         run: |
           docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
           docker push registry.heroku.com/sem-test-1101/web
+          
+          curl https://cli-assets.heroku.com/install.sh | sh
+          heroku --version # verify install
+          echo "machine api.heroku.com\n\tlogin mcantacu@andrew.cmu.edu\n\tpassword $HEROKU_AUTH_TOKEN" > ~/.netrc
+          
+          heroku container:release web -a sem-test-1101
         env:
           HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
+  
+  deploy-ml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build container
+        working-directory: ./model
+        run: | 
+          docker build -t model .
+          docker tag model registry.heroku.com/sem-ml-1101/web
+      - name: login to heroku and push image
+        run: |
+          APP_NAME=sem-ml-1101
+
+          docker login --usrename=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
+          docker push registry.heroku.com/$APP_NAME/web
+          
+          curl https://cli-assets.heroku.com/install.sh | sh
+          heroku --version
+          echo "machine api.heroku.com\n\tlogin mcantacu@andrew.cmu.edu\n\tpassword $HEROKU_AUTH_TOKEN" > ~/.netrc
+          
+          heroku container:release web -a APP_NAME
+
           

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -1,0 +1,17 @@
+name: Test server
+on: 
+  push:
+    paths:
+      - 'server/**'
+  workflow_dispatch:
+
+jobs: 
+  test-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: test server
+        working-directory: ./server
+        run: | 
+          go test ./...
+        

--- a/server/README.md
+++ b/server/README.md
@@ -30,6 +30,7 @@ You will need the following to run the server:
 | `AWS_REGION`            | Yes      | AWS region to use                                            |
 | `S3_BUCKET_NAME`        | Yes      | Name of the S3 Bucket to use                                 |
 | `PEGASUS_API_URL`       | Yes      | Url of the Pegasus api. Api must expose `/paraphrase` route. |
+| `PORT`                  | No       | Default `8080`, the port on which to expose the API          | 
 
 ## Testing
 To run the unit tests of the application, run the following command: `go test ./...` in the `server` directory.

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	aCtx "server/context"
 	"server/router"
 
@@ -29,10 +30,13 @@ func main() {
 
 	ctx := aCtx.InitAppContext()
 
-	port := 8080
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
 	r := router.Router(ctx)
 	// r.Use(AppContextMiddleware(ctx))
 
-	fmt.Printf("Starting server on port %d\n", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), r))
+	fmt.Printf("Starting server on port %s\n", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), r))
 }


### PR DESCRIPTION
Used Github actions to set up continuous integration and deployment on heroku for back end server and  model.
Due to heroku limits model does not currently function
Automatic deployment happens on branch release
APIs are accessible here:
| API      | url                                                                 |
| -------|-----------------------------------------| 
| server | `https://sem-test-1101.herokuapp.com/` |
| model | `https://sem-ml-1101.herokuapp.com/`   |